### PR TITLE
ci: add github actions quality-gate workflow + README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build, Test, Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Setup JDK 21 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: app/frontend/package-lock.json
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build (processor tests + app + KSP + tsc --strict)
+        run: ./gradlew build --stacktrace --no-daemon
+
+      - name: Upload coverage to Codecov
+        if: always()
+        continue-on-error: true
+        uses: codecov/codecov-action@v4
+        with:
+          files: processor/build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            processor/build/reports/tests/test/**
+            processor/build/reports/jacoco/test/html/**
+            app/frontend/.typecheck-ok
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           files: processor/build/reports/jacoco/test/jacocoTestReport.xml
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test reports on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 # SPIA
 
+[![CI](https://github.com/lyutvs/spia/actions/workflows/ci.yml/badge.svg)](https://github.com/lyutvs/spia/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/lyutvs/spia/branch/main/graph/badge.svg)](https://codecov.io/gh/lyutvs/spia) [![Maven Central (plugin)](https://img.shields.io/maven-central/v/io.github.lyutvs/gradle-plugin?label=gradle-plugin)](https://central.sonatype.com/artifact/io.github.lyutvs/gradle-plugin) [![Maven Central (processor)](https://img.shields.io/maven-central/v/io.github.lyutvs/processor?label=processor)](https://central.sonatype.com/artifact/io.github.lyutvs/processor) [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
 > Scan your Spring Boot controllers at compile time and automatically
 > generate a **type-safe TypeScript SDK** ready to drop into your frontend.
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs `./gradlew build` (processor tests + KSP + `tsc --strict`) on PR to main, push to main, and manual dispatch.
- Uploads JaCoCo XML to Codecov (non-blocking); uploads test reports as artifacts on failure.
- Adds 5 status badges to README: CI, Codecov, Maven Central (×2), License.

## Test plan
- [ ] GitHub Actions "CI / Build, Test, Typecheck" runs and passes on this PR
- [ ] `codecov/codecov-action@v4` step finishes without failing the job
- [ ] README badges render correctly in the PR preview
- [ ] After merge to `main`, CI badge resolves to green on the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)