### PR TITLE
ci(release): add tag-push release workflow

### DIFF
--- a/.github/scripts/extract-changelog.sh
+++ b/.github/scripts/extract-changelog.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Extracts the CHANGELOG section for a given version (without the leading `v`).
+# Usage: extract-changelog.sh <version>
+# Example: extract-changelog.sh 0.2.0
+# Prints the section body (lines between `## [<version>]` and the next `## [`) to stdout.
+# If no matching section is found, prints a placeholder notice to stdout and logs a ::warning::.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "::error::version argument required" >&2
+  exit 1
+fi
+
+CHANGELOG_FILE="${CHANGELOG_FILE:-CHANGELOG.md}"
+if [ ! -f "$CHANGELOG_FILE" ]; then
+  echo "::error::$CHANGELOG_FILE not found" >&2
+  exit 1
+fi
+
+NOTES=$(awk -v v="$VERSION" '
+  index($0, "## [" v "]") == 1 { found=1; next }
+  found && index($0, "## [") == 1 { exit }
+  found { print }
+' "$CHANGELOG_FILE")
+
+# Trim leading blank lines
+NOTES=$(printf '%s\n' "$NOTES" | awk 'NF{found=1} found{print}')
+
+if [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]; then
+  echo "::warning::No CHANGELOG section found for v$VERSION — using placeholder" >&2
+  printf '%s\n' "_CHANGELOG section for v$VERSION was not found. Please edit this release manually before publishing._"
+  exit 0
+fi
+
+printf '%s\n' "$NOTES"

--- a/.github/scripts/verify-tag.sh
+++ b/.github/scripts/verify-tag.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verifies: (a) the pushed tag's version matches `version=` in gradle.properties,
+# and (b) the tagged commit is an ancestor of origin/main.
+# Reads GITHUB_REF_NAME and GITHUB_SHA from env (set by GitHub Actions).
+# Exit 0 = pass; exit 1 = fail with error via ::error:: annotation.
+
+set -euo pipefail
+
+: "${GITHUB_REF_NAME:?GITHUB_REF_NAME is required (e.g. v0.3.0)}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+
+TAG_VERSION="${GITHUB_REF_NAME#v}"
+
+if [ -z "$TAG_VERSION" ] || [ "$TAG_VERSION" = "$GITHUB_REF_NAME" ]; then
+  echo "::error::Tag '$GITHUB_REF_NAME' does not start with 'v' — refusing to proceed"
+  exit 1
+fi
+
+FILE_VERSION=$(awk -F= '/^version=/ {gsub(/[[:space:]]/, "", $2); print $2}' gradle.properties)
+
+if [ -z "$FILE_VERSION" ]; then
+  echo "::error::Could not read version= from gradle.properties"
+  exit 1
+fi
+
+if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+  echo "::error::Tag v$TAG_VERSION does not match gradle.properties version=$FILE_VERSION"
+  exit 1
+fi
+
+echo "✓ Tag/version match: v$TAG_VERSION"
+
+# Ancestor check: confirm the tagged commit is on main.
+git fetch origin main --quiet
+
+if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+  echo "::error::Tagged commit $GITHUB_SHA is not an ancestor of origin/main"
+  exit 1
+fi
+
+echo "✓ Tagged commit is on main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify tag and version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag matches version and is on main
+        run: bash .github/scripts/verify-tag.sh
+
+  build-and-stage:
+    name: Build, sign, and stage to Central Portal
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: verify
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Setup JDK 21 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: app/frontend/package-lock.json
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Quality gate (build + tests + tsc --strict)
+        run: ./gradlew build --stacktrace --no-daemon
+
+      - name: mavenLocal preflight — publish locally, then exercise external-consumer path
+        run: |
+          ./gradlew :gradle-plugin:publishToMavenLocal :processor:publishToMavenLocal --stacktrace --no-daemon
+          ./gradlew -p docs/samples/mavenlocal-consumer clean build --stacktrace --no-daemon
+
+      - name: Stage to Maven Central Portal (no auto-release)
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
+        run: |
+          ./gradlew \
+            :gradle-plugin:publishToMavenCentral \
+            :processor:publishToMavenCentral \
+            --stacktrace --no-daemon
+
+      - name: Upload build reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-failure-reports
+          path: |
+            **/build/reports/**
+            **/build/publications/**
+          retention-days: 14
+          if-no-files-found: ignore
+
+  draft-release:
+    name: Create draft GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: build-and-stage
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract CHANGELOG section
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=$(bash .github/scripts/extract-changelog.sh "$VERSION")
+          {
+            echo 'body<<EOF_NOTES'
+            printf '%s\n' "$NOTES"
+            echo 'EOF_NOTES'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.body }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -95,7 +95,70 @@ exact plugin resolution path an external consumer takes.
 A green build + a populated `docs/samples/mavenlocal-consumer/frontend/api.ts`
 means the release bundle is self-contained and ready to upload to Central.
 
-## 5. Actual release
+## 5. Cutting a release (tag-push, automated)
+
+Releases are produced by `.github/workflows/release.yml` on tag push. The
+maintainer's local workflow is:
+
+```bash
+# 1. Move `## [Unreleased]` items in CHANGELOG.md to a new
+#    `## [X.Y.Z] - YYYY-MM-DD` section. Edit `gradle.properties`:
+#    version=X.Y.Z. Commit both.
+git add CHANGELOG.md gradle.properties
+git commit -m "chore(release): prepare vX.Y.Z"
+git push origin main
+
+# 2. Tag the commit and push the tag.
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+The workflow then runs three jobs:
+
+1. **verify** — checks that the tag's `X.Y.Z` matches `gradle.properties`
+   `version=` and that the tagged commit is on `main`. Fails fast on
+   mismatch.
+2. **build-and-stage** — runs `./gradlew build`, the mavenLocal dry-run
+   preflight against `docs/samples/mavenlocal-consumer`, then
+   `publishToMavenCentral` for both artifacts (staged on Central Portal,
+   **not** auto-released).
+3. **draft-release** — creates a GitHub Release marked as **draft** with
+   the `## [X.Y.Z]` section of `CHANGELOG.md` as the body.
+
+### Required secrets
+
+| Secret | Value | Source |
+|---|---|---|
+| `MAVEN_CENTRAL_USERNAME` | Portal User Token username | central.sonatype.com → View Account → Generate User Token |
+| `MAVEN_CENTRAL_PASSWORD` | Portal User Token password | same screen |
+| `SIGNING_IN_MEMORY_KEY` | Armored GPG private key (entire `-----BEGIN PGP PRIVATE KEY BLOCK-----` through `-----END PGP PRIVATE KEY BLOCK-----`) | `gpg --export-secret-keys --armor <KEY_ID>` |
+| `SIGNING_IN_MEMORY_KEY_PASSWORD` | GPG key passphrase | — |
+
+For the armored GPG key, pipe the exported file directly to avoid
+clipboard line-ending corruption:
+
+```bash
+gpg --export-secret-keys --armor <KEY_ID> | gh secret set SIGNING_IN_MEMORY_KEY --repo lyutvs/spia
+```
+
+## 6. Post-release review (two manual gates)
+
+After the workflow completes:
+
+1. **Central Portal** — open https://central.sonatype.com →
+   *Deployments* → locate the staged deployment for your version →
+   review signatures, javadoc, POM → click **Release**. Maven Central
+   proper reflects the release within 10–30 minutes.
+2. **GitHub Release** — open
+   https://github.com/lyutvs/spia/releases → locate the draft for
+   `vX.Y.Z` → review the auto-extracted notes → check *Set as a
+   pre-release* if the tag is an alpha/rc → click **Publish release**.
+
+If something looks wrong during post-release review, drop the staged
+deployment on Central Portal and delete the tag locally + remotely,
+then re-tag after fixing the issue.
+
+## 7. Fallback: local-only release (when CI is unavailable)
 
 ```bash
 # 1. Clean build + tsc --strict gate
@@ -113,8 +176,12 @@ git push origin main
 ```
 
 Central Portal performs its own validation (signatures, javadoc, pom
-completeness) before publishing to Maven Central proper — that can take
-10–30 minutes. Check the portal UI for progress.
+completeness) before publishing to Maven Central proper — that can
+take 10–30 minutes. Check the portal UI for progress.
+
+This path requires the maintainer to have the GPG key and Portal
+credentials configured locally (see GPG section below). Prefer the
+tag-push flow in section 5 whenever possible.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` that triggers on `v*` tag push and runs three jobs: `verify` → `build-and-stage` → `draft-release`.
- Adds `.github/scripts/verify-tag.sh` and `.github/scripts/extract-changelog.sh`, both unit-tested locally against known CHANGELOG entries.
- Updates `docs/RELEASING.md` to make tag-push the default flow, with the local-only flow preserved as a fallback.

Implements the A-safe variant of the release automation spec: tag push produces a **staged** Central deployment and a **draft** GH Release, leaving two human gates (Portal Release click + GH Release Publish click) before anything goes public.

## Required GitHub secrets (maintainer sets before first tag)
- `MAVEN_CENTRAL_USERNAME`
- `MAVEN_CENTRAL_PASSWORD`
- `SIGNING_IN_MEMORY_KEY`
- `SIGNING_IN_MEMORY_KEY_PASSWORD`

## Test plan
- [ ] CI workflow (`ci.yml`) passes on this PR (no source changes, should be green)
- [ ] Merge PR to `main`
- [ ] Push deliberate bad tag (mismatch) to confirm `verify` fails fast
- [ ] Delete bad tag and verify no side effects
- [ ] First real release (v0.3.0) validates end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)