### PR TITLE
community: add issue/PR templates and SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a problem with SPIA
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. A minimal reproduction
+        dramatically shortens the path to a fix.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug — what you did, what you saw, how it differed from what you expected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: |
+        The smallest Spring Boot controller + DTOs that produce the problem.
+        Include the `spia { ... }` DSL config you're using.
+      render: kotlin
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-ts
+    attributes:
+      label: Expected TypeScript output
+      description: What TypeScript did you expect to be generated?
+      render: typescript
+
+  - type: textarea
+    id: actual-ts
+    attributes:
+      label: Actual TypeScript output
+      description: What was actually generated?
+      render: typescript
+
+  - type: input
+    id: spia-version
+    attributes:
+      label: SPIA version
+      placeholder: 0.2.0
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, JDK, Kotlin, KSP, Gradle versions.
+      placeholder: macOS 14, JDK 21, Kotlin 2.1.20, KSP 2.1.20-1.0.31, Gradle 8.10.2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an enhancement or new capability
+labels: [enhancement]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you trying to do? Why do you need this? What's currently blocking you?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: If you have an idea for how to implement this, describe it here.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you found other ways to solve this? What are their trade-offs?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- Brief description of what this PR changes and why. -->
+
+## Related
+
+<!-- Link issues, RFCs, or prior discussion: "Closes #123", "Relates to #456". -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (existing API behavior changes)
+- [ ] Docs / build / CI (no runtime code change)
+
+## Test plan
+
+- [ ] `./gradlew build` passes locally (or CI is green)
+- [ ] New/modified behavior covered by a test case in `processor/src/test/kotlin/.../ProcessorSmokeTest.kt`
+- [ ] `CHANGELOG.md` `[Unreleased]` updated (for user-visible changes)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+| Version  | Supported          |
+|----------|--------------------|
+| 0.2.x    | :white_check_mark: |
+| < 0.2    | :x:                |
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue for security vulnerabilities.
+
+Use GitHub's private vulnerability reporting:
+<https://github.com/lyutvs/spia/security/advisories/new>
+
+Include:
+
+- A description of the vulnerability
+- Minimal reproduction (Kotlin controller + `spia { ... }` config that triggers it)
+- Affected SPIA versions
+- Your assessment of the severity and blast radius
+
+## What to expect
+
+- **Acknowledgement**: within 72 hours
+- **Initial assessment**: within 7 days
+- **Fix timeline**: depends on severity; critical issues patched within 30 days when feasible
+- **Credit**: with your permission, reporters are credited in the release notes
+
+## Threat models in scope
+
+SPIA is a compile-time KSP processor — there is **no runtime component** deployed on the consumer's server. The primary threat models this policy covers:
+
+1. **Supply chain** — malicious code injected into published Maven Central artifacts. Mitigated by GPG-signed releases (`io.github.lyutvs:gradle-plugin`, `io.github.lyutvs:processor`) and a deterministic build pipeline with staged review on Central Portal before release.
+2. **Generated code correctness** — the generated TypeScript SDK incorrectly handles untrusted input, enabling injection or data leakage in the consumer's frontend (e.g., improperly escaped path variables, header-injection, prototype-pollution through generated types).
+3. **Build-time processor behavior** — a malicious `@RestController` or DTO on the consumer's codebase triggering KSP processor behavior that reads/leaks environment secrets or writes outside the configured `outputPath`.
+
+Reports on any of these threat models are in scope. Issues unrelated to SPIA's behavior (e.g., a Spring Boot CVE, a Kotlin compiler bug) should be reported to their respective projects.


### PR DESCRIPTION
## Summary
- Adds 3 issue-template files: `bug_report.yml` (structured form with Kotlin repro + env), `feature_request.yml` (use case + proposal), `config.yml` (disables blank issues).
- Adds `.github/pull_request_template.md` aligned to the project's CI/testing workflow.
- Adds `SECURITY.md` at repo root routing vulnerability reports to GitHub Private Vulnerability Reporting, with SPIA-specific threat models.

Branch protection and Private Vulnerability Reporting are applied after merge via gh api.

## Test plan
- [ ] CI passes on this PR (pure doc/config addition, should be green)
- [ ] After merge: https://github.com/lyutvs/spia/issues/new/choose shows the two templates
- [ ] After merge: `SECURITY.md` appears in the repo's "Security" tab
- [ ] After merge: branch protection applied via `gh api` and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)