### PR TITLE
deps: upgrade Spring Boot 3.4 to 4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm") version "2.3.21" apply false
     kotlin("plugin.spring") version "2.3.21" apply false
     id("com.google.devtools.ksp") version "2.3.7" apply false
-    id("org.springframework.boot") version "3.4.1" apply false
+    id("org.springframework.boot") version "4.0.5" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
 }
 

--- a/docs/samples/mavenlocal-consumer/server/build.gradle.kts
+++ b/docs/samples/mavenlocal-consumer/server/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-    id("org.springframework.boot") version "3.4.1"
+    id("org.springframework.boot") version "4.0.5"
     id("io.spring.dependency-management") version "1.1.7"
-    kotlin("jvm") version "2.1.20"
-    kotlin("plugin.spring") version "2.1.20"
-    id("com.google.devtools.ksp") version "2.1.20-1.0.31"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.spring") version "2.3.21"
+    id("com.google.devtools.ksp") version "2.3.7"
     id("io.github.lyutvs.spia") version "0.1.0"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 kspVersion=2.3.7
-springBootVersion=3.4.1
+springBootVersion=4.0.5
 kotlinVersion=2.3.21
 
 group=io.github.lyutvs


### PR DESCRIPTION
## Summary
Demo app-only upgrade of Spring Boot 3.4.1 → 4.0.5. SPIA's published artifacts (gradle-plugin, processor) do not depend on Spring at runtime — the processor detects Spring annotations by FQN string, stable across major versions — so this only affects the sandbox/demo and the mavenLocal consumer sample.

## Changes
- `gradle.properties`: `springBootVersion` 3.4.1 → 4.0.5
- `build.gradle.kts`: Spring Boot plugin declaration
- `docs/samples/mavenlocal-consumer/server/build.gradle.kts`: bumped Spring Boot + aligned Kotlin/KSP to the 2.3 stack that Spring Boot 4 requires

Spring Boot 4 requires Kotlin 2.2+, provided by the preceding PR #20 (Kotlin 2.3 migration). This PR depends on main containing that commit.

## Test plan
- [x] `./gradlew build` green locally (21 tasks, all pass)
- [x] `./gradlew -p docs/samples/mavenlocal-consumer clean build` green
- [ ] CI passes on this PR

## Note
This re-addresses the original Dependabot PR #13 (which we'd closed with `@dependabot ignore this major version`). Doing it manually here because:
1. The app/ module is a demo, low-risk.
2. The ignore was a temporary hedge while we settled the Kotlin stack upgrade; now that Kotlin 2.3 is in place, Spring 4 is straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)